### PR TITLE
[FEAT] 프로젝트 전역 설정 + 함께 고민글 결정API

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   "dependencies": {
     "@prisma/client": "^4.5.0",
     "bcryptjs": "^2.4.3",
+    "dotenv": "^16.0.3",
     "eslint": "^8.30.0",
     "express": "^4.18.2",
     "express-validator": "^6.14.2",

--- a/src/common/error/exceptions/customExceptions.ts
+++ b/src/common/error/exceptions/customExceptions.ts
@@ -1,0 +1,16 @@
+class ClientException extends Error {
+  statusCode: number;
+  constructor(msg: string | undefined = undefined, statusCode: number = 400) {
+    super(msg);
+    this.statusCode = statusCode;
+  }
+}
+class CustomException extends Error {
+  statusCode: number;
+  constructor(msg: string | undefined = undefined, statusCode: number = 500) {
+    super(msg);
+    this.statusCode = statusCode;
+  }
+}
+
+export { ClientException, CustomException };

--- a/src/common/error/handler.ts
+++ b/src/common/error/handler.ts
@@ -1,0 +1,15 @@
+import { NextFunction, Request, Response } from "express";
+import statusCode from "../../constants/statusCode";
+import responseMessage from "../../constants/responseMessage";
+
+const globalExceptionHandler = async (err: any, req: Request, res: Response, next: NextFunction) => {
+  const status = err?.statusCode || statusCode.INTERNAL_SERVER_ERROR;
+  res.status(status).json({
+    status,
+    success: false,
+    message: err?.message || responseMessage.INTERNAL_SERVER_ERROR
+  });
+  next(err);
+};
+
+export default globalExceptionHandler;

--- a/src/common/error/handler.ts
+++ b/src/common/error/handler.ts
@@ -1,14 +1,13 @@
 import { NextFunction, Request, Response } from "express";
 import statusCode from "../../constants/statusCode";
 import responseMessage from "../../constants/responseMessage";
-
+import { fail } from "../../constants/response";
 const globalExceptionHandler = async (err: any, req: Request, res: Response, next: NextFunction) => {
   const status = err?.statusCode || statusCode.INTERNAL_SERVER_ERROR;
-  res.status(status).json({
+  res.status(status).send(fail(
     status,
-    success: false,
-    message: err?.message || responseMessage.INTERNAL_SERVER_ERROR
-  });
+    err?.message || responseMessage.INTERNAL_SERVER_ERROR
+  ));
   next(err);
 };
 

--- a/src/controller/index.ts
+++ b/src/controller/index.ts
@@ -1,0 +1,3 @@
+import worryWithController from './worryWithController';
+
+export { worryWithController };

--- a/src/controller/worryWithController.ts
+++ b/src/controller/worryWithController.ts
@@ -14,11 +14,11 @@ const sendOk = (res: Response, message: string, data?: any) => {
 
 const updateFinalOption = async (req: Request, res: Response, next: NextFunction) => {
   try {
-    const { worryWithId, chosenOptionId } = req.body;
-    if (!worryWithId || !chosenOptionId) {
+    const { userId, worryWithId, chosenOptionId } = req.body;
+    if (!userId || !worryWithId || !chosenOptionId) {
       throw new ClientException("필요한 값이 없습니다.");
     }
-    await worryWithService.chooseFinalOption(worryWithId, chosenOptionId);
+    await worryWithService.chooseFinalOption(userId, worryWithId, chosenOptionId);
     sendOk(res, "나의고민 최종결정 성공");
   } catch (error) {
     next(error);

--- a/src/controller/worryWithController.ts
+++ b/src/controller/worryWithController.ts
@@ -1,0 +1,28 @@
+import { NextFunction, Request, Response } from "express";
+import { ClientException } from "../common/error/exceptions/customExceptions";
+import statusCode from "../constants/statusCode";
+import { worryWithService } from '../service';
+
+const sendOk = (res: Response, message: string, data?: any) => {
+  res.status(statusCode.OK).json({
+    status: statusCode.OK,
+    success: true,
+    message,
+    data
+  });
+}
+
+const updateFinalOption = async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const { worryWithId, chosenOptionId } = req.body;
+    if (!worryWithId || !chosenOptionId) {
+      throw new ClientException("필요한 값이 없습니다.");
+    }
+    await worryWithService.chooseFinalOption(worryWithId, chosenOptionId);
+    sendOk(res, "나의고민 최종결정 성공");
+  } catch (error) {
+    next(error);
+  }
+};
+
+export default { updateFinalOption };

--- a/src/controller/worryWithController.ts
+++ b/src/controller/worryWithController.ts
@@ -1,16 +1,8 @@
 import { NextFunction, Request, Response } from "express";
 import { ClientException } from "../common/error/exceptions/customExceptions";
+import { success } from "../constants/response";
 import statusCode from "../constants/statusCode";
 import { worryWithService } from '../service';
-
-const sendOk = (res: Response, message: string, data?: any) => {
-  res.status(statusCode.OK).json({
-    status: statusCode.OK,
-    success: true,
-    message,
-    data
-  });
-}
 
 const updateFinalOption = async (req: Request, res: Response, next: NextFunction) => {
   try {
@@ -19,7 +11,8 @@ const updateFinalOption = async (req: Request, res: Response, next: NextFunction
       throw new ClientException("필요한 값이 없습니다.");
     }
     await worryWithService.chooseFinalOption(userId, worryWithId, chosenOptionId);
-    sendOk(res, "나의고민 최종결정 성공");
+
+    res.status(statusCode.OK).send(success(statusCode.OK, "나의고민 최종결정 성공"));
   } catch (error) {
     next(error);
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,9 @@
 import express, { NextFunction, Request, Response } from "express";
 import router from "./router";
+import globalExceptionHandler from "./common/error/handler";
+import * as dotenv from 'dotenv';
+
+dotenv.config();
 
 const app = express(); // express 객체 받아옴
 const PORT = 3000; // 사용할 port를 3000번으로 설정

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,13 @@ app.get("/", (req: Request, res: Response, next: NextFunction) => {
   res.send("마! 이게 서버다!!!!!!!!!!!!!!!!!!!!");
 });
 
+app.use(globalExceptionHandler);
+
+// dev
+app.use((err: any, req: Request, res: Response, next: NextFunction) => {
+  console.log(err);
+})
+
 app.listen(PORT, () => {
   console.log(`
         #############################################

--- a/src/middlwares/auth.ts
+++ b/src/middlwares/auth.ts
@@ -6,27 +6,31 @@ import tokenType from "../constants/tokenType";
 import jwtHandler from "../modules/jwtHandler";
 
 export default async (req: Request, res: Response, next: NextFunction) => {
-  const token = req.headers.authorization?.split(" ").reverse()[0]; //? Bearer ~~ 에서 토큰만 파싱
-  if (!token) return res.status(sc.UNAUTHORIZED).send(fail(sc.UNAUTHORIZED, rm.EMPTY_TOKEN));
+  // dev
+  req.body.userId = 3;
+  next();
 
-  try {
-    const decoded = jwtHandler.verify(token); //? jwtHandler에서 만들어둔 verify로 토큰 검사
+  // const token = req.headers.authorization?.split(" ").reverse()[0]; //? Bearer ~~ 에서 토큰만 파싱
+  // if (!token) return res.status(sc.UNAUTHORIZED).send(fail(sc.UNAUTHORIZED, rm.EMPTY_TOKEN));
 
-    //? 토큰 에러 분기 처리
-    if (decoded === tokenType.TOKEN_EXPIRED)
-      return res.status(sc.UNAUTHORIZED).send(fail(sc.UNAUTHORIZED, rm.EXPIRED_TOKEN));
-    if (decoded === tokenType.TOKEN_INVALID)
-      return res.status(sc.UNAUTHORIZED).send(fail(sc.UNAUTHORIZED, rm.INVALID_TOKEN));
+  // try {
+  //   const decoded = jwtHandler.verify(token); //? jwtHandler에서 만들어둔 verify로 토큰 검사
 
-    //? decode한 후 담겨있는 userId를 꺼내옴
-    const userId: number = (decoded as JwtPayload).userId;
-    if (!userId) return res.status(sc.UNAUTHORIZED).send(fail(sc.UNAUTHORIZED, rm.INVALID_TOKEN));
+  //   //? 토큰 에러 분기 처리
+  //   if (decoded === tokenType.TOKEN_EXPIRED)
+  //     return res.status(sc.UNAUTHORIZED).send(fail(sc.UNAUTHORIZED, rm.EXPIRED_TOKEN));
+  //   if (decoded === tokenType.TOKEN_INVALID)
+  //     return res.status(sc.UNAUTHORIZED).send(fail(sc.UNAUTHORIZED, rm.INVALID_TOKEN));
 
-    //? 얻어낸 userId 를 Request Body 내 userId 필드에 담고, 다음 미들웨어로 넘김( next() )
-    req.body.userId = userId;
-    next();
-  } catch (error) {
-    console.log(error);
-    res.status(sc.INTERNAL_SERVER_ERROR).send(fail(sc.INTERNAL_SERVER_ERROR, rm.INTERNAL_SERVER_ERROR));
-  }
+  //   //? decode한 후 담겨있는 userId를 꺼내옴
+  //   const userId: number = (decoded as JwtPayload).userId;
+  //   if (!userId) return res.status(sc.UNAUTHORIZED).send(fail(sc.UNAUTHORIZED, rm.INVALID_TOKEN));
+
+  //   //? 얻어낸 userId 를 Request Body 내 userId 필드에 담고, 다음 미들웨어로 넘김( next() )
+  //   req.body.userId = userId;
+  //   next();
+  // } catch (error) {
+  //   console.log(error);
+  //   res.status(sc.INTERNAL_SERVER_ERROR).send(fail(sc.INTERNAL_SERVER_ERROR, rm.INTERNAL_SERVER_ERROR));
+  // }
 };

--- a/src/repository/index.ts
+++ b/src/repository/index.ts
@@ -1,0 +1,4 @@
+import worryWithRepository from './worryWithRepository';
+import withOptionRepository from './withOptionRepository';
+
+export { worryWithRepository, withOptionRepository };

--- a/src/repository/prismaClient.ts
+++ b/src/repository/prismaClient.ts
@@ -1,0 +1,5 @@
+import { PrismaClient } from "@prisma/client";
+
+const prisma = new PrismaClient();
+
+export default prisma;

--- a/src/repository/withOptionRepository.ts
+++ b/src/repository/withOptionRepository.ts
@@ -1,0 +1,12 @@
+import { withOption } from "@prisma/client";
+import prisma from "./prismaClient";
+
+const findById = async (id: number): Promise<withOption | null> => {
+  return await prisma.withOption.findUnique({
+    where: {
+      id
+    }
+  });
+};
+
+export default { findById };

--- a/src/repository/worryWithRepository.ts
+++ b/src/repository/worryWithRepository.ts
@@ -1,0 +1,23 @@
+import { PrismaClient, worryWith } from "@prisma/client";
+import prisma from "./prismaClient";
+
+const findById = async (id: number): Promise<worryWith | null> => {
+  return prisma.worryWith.findUnique({
+    where: {
+      id
+    }
+  });
+};
+
+const updateFinalOptionById = async (id: number, optionId: number) => {
+  await prisma.worryWith.update({
+    where: {
+      id
+    },
+    data: {
+      finalOption: optionId
+    }
+  });
+};
+
+export default { findById, updateFinalOptionById };

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -1,5 +1,8 @@
 import { Router } from "express";
+import worryWithRouter from './worryWithRouter';
 
 const router: Router = Router();
+
+router.use('/worryWith', worryWithRouter);
 
 export default router;

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -3,6 +3,6 @@ import worryWithRouter from './worryWithRouter';
 
 const router: Router = Router();
 
-router.use('/worryWith', worryWithRouter);
+router.use('/worry/with', worryWithRouter);
 
 export default router;

--- a/src/router/worryWithRouter.ts
+++ b/src/router/worryWithRouter.ts
@@ -1,0 +1,8 @@
+import { Router } from 'express';
+import { worryWithController } from '../controller';
+
+const router = Router();
+
+router.patch('/', worryWithController.updateFinalOption);
+
+export default router;

--- a/src/router/worryWithRouter.ts
+++ b/src/router/worryWithRouter.ts
@@ -1,8 +1,9 @@
 import { Router } from 'express';
 import { worryWithController } from '../controller';
+import { auth } from '../middlwares';
 
 const router = Router();
 
-router.patch('/', worryWithController.updateFinalOption);
+router.patch('/', auth, worryWithController.updateFinalOption);
 
 export default router;

--- a/src/service/index.ts
+++ b/src/service/index.ts
@@ -1,0 +1,3 @@
+import worryWithService from "./worryWithService";
+
+export { worryWithService };

--- a/src/service/worryWithService.ts
+++ b/src/service/worryWithService.ts
@@ -1,15 +1,21 @@
-import { IllegalStateException } from "../common/error/exceptions/customExceptions";
+
+import { ClientException } from "../common/error/exceptions/customExceptions";
+import statusCode from "../constants/statusCode";
 import { withOptionRepository, worryWithRepository } from "../repository"
 
-const chooseFinalOption = async (worryWithId: number, optionId: number) => {
+const chooseFinalOption = async (userId: number, worryWithId: number, optionId: number) => {
   const worryWith = await worryWithRepository.findById(worryWithId);
   if (!worryWith) {
-    throw new IllegalStateException("해당하는 아이디의 걱정글이 존재하지 않습니다");
+    throw new ClientException("해당하는 아이디의 걱정글이 존재하지 않습니다");
+  }
+
+  if (worryWith.userId != userId) {
+    throw new ClientException("고민글 작성자가 아닙니다.", statusCode.UNAUTHORIZED);
   }
 
   const chosenOption = await withOptionRepository.findById(optionId);
   if (!chosenOption) {
-    throw new IllegalStateException("해당하는 아이디의 옵션이 존재하지 않습니다");
+    throw new ClientException("해당하는 아이디의 옵션이 존재하지 않습니다");
   }
 
   await worryWithRepository.updateFinalOptionById(worryWithId, optionId);

--- a/src/service/worryWithService.ts
+++ b/src/service/worryWithService.ts
@@ -1,0 +1,18 @@
+import { IllegalStateException } from "../common/error/exceptions/customExceptions";
+import { withOptionRepository, worryWithRepository } from "../repository"
+
+const chooseFinalOption = async (worryWithId: number, optionId: number) => {
+  const worryWith = await worryWithRepository.findById(worryWithId);
+  if (!worryWith) {
+    throw new IllegalStateException("해당하는 아이디의 걱정글이 존재하지 않습니다");
+  }
+
+  const chosenOption = await withOptionRepository.findById(optionId);
+  if (!chosenOption) {
+    throw new IllegalStateException("해당하는 아이디의 옵션이 존재하지 않습니다");
+  }
+
+  await worryWithRepository.updateFinalOptionById(worryWithId, optionId);
+};
+
+export default { chooseFinalOption };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1957,6 +1957,11 @@ doctrine@^3.0.0:
   dependencies:
     esutils "^2.0.2"
 
+dotenv@^16.0.3:
+  version "16.0.3"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-16.0.3.tgz#115aec42bac5053db3c456db30cc243a5a836a07"
+  integrity sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ==
+
 ecdsa-sig-formatter@1.0.11:
   version "1.0.11"
   resolved "https://registry.yarnpkg.com/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz#ae0f0fa2d85045ef14a817daa3ce9acd0489e5bf"


### PR DESCRIPTION
**우선순위**

<!--
D-0 (ASAP)
긴급한 수정사항으로 바로 리뷰해 주세요.
앱의 오류로 인해 장애가 발생하거나, 빌드가 되지 않는 등 긴급 이슈가 발생할 때 사용합니다.
D-N (Within N days)
N일 이내에 리뷰해 주세요
-->

D-1

**변경사항**

- 기본적인 예외를 정의했습니다. (ClientException, CustomException)
  - 원래 서비스 예외는 프레젠트 영역에 의존하지 않는 것이 바람직하지만, 구현 난이도가 너무 높아질 것을 우려해 간단하게 두 예외에는 Http status code를 포함하도록 만들었어요 (이거 구두로 설명할테니 이해 안돼도 패스)
- prismaClient 인스턴스를 프로젝트에서 한번만 생성하고 `repository/prismaClient.ts` 에서 관리하게 했어요.
- jwt를 디코드하는 auth 미들웨어를 개발 버전으로 하드코딩 해두었습니다.

자세한 건 코드를 봐주세요

**유의사항**

<!--
- 영향범위
- 중점적으로 pr 리뷰해줬으면 하는 부분
-->

코멘트 남길게요

**참조**

<!--
변경사항에 대해서 파악할 수 있는 링크 (노션, 슬랙, 위키 등)
-->
