### PR TITLE
[FEAT] 고민글 전체 조회 구현 , API 테스트파일 생성

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,12 +10,15 @@
       "license": "MIT",
       "dependencies": {
         "@prisma/client": "^4.5.0",
+        "@types/supertest": "^2.0.12",
         "bcryptjs": "^2.4.3",
+        "dotenv": "^16.0.3",
         "eslint": "^8.30.0",
         "express": "^4.18.2",
         "express-validator": "^6.14.2",
         "jsonwebtoken": "^8.5.1",
-        "prisma": "^4.5.0"
+        "prisma": "^4.5.0",
+        "supertest": "^6.3.3"
       },
       "devDependencies": {
         "@babel/core": "^7.20.7",
@@ -28,7 +31,7 @@
         "@types/jsonwebtoken": "^8.5.9",
         "@types/node": "^18.11.9",
         "babel-jest": "^29.3.1",
-        "husky": "^8.0.3",
+        "husky": "^8.0.0",
         "jest": "^29.3.1",
         "nodemon": "^2.0.20",
         "ts-jest": "^29.0.3",
@@ -2680,6 +2683,11 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/cookiejar": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@types/cookiejar/-/cookiejar-2.1.2.tgz",
+      "integrity": "sha512-t73xJJrvdTjXrn4jLS9VSGRbz0nUY3cl2DMGDU48lKl+HR9dbbjW2A9r3g40VA++mQpy6uuHg33gy7du2BKpog=="
+    },
     "node_modules/@types/express": {
       "version": "4.17.15",
       "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.15.tgz",
@@ -2774,8 +2782,7 @@
     "node_modules/@types/node": {
       "version": "18.11.18",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.18.tgz",
-      "integrity": "sha512-DHQpWGjyQKSHj3ebjFI/wRKcqQcdR+MoFBygntYOZytCqNfkd2ZC4ARDJ2DQqhjH5p85Nnd3jhUJIXrszFX/JA==",
-      "dev": true
+      "integrity": "sha512-DHQpWGjyQKSHj3ebjFI/wRKcqQcdR+MoFBygntYOZytCqNfkd2ZC4ARDJ2DQqhjH5p85Nnd3jhUJIXrszFX/JA=="
     },
     "node_modules/@types/prettier": {
       "version": "2.7.2",
@@ -2810,6 +2817,23 @@
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz",
       "integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==",
       "dev": true
+    },
+    "node_modules/@types/superagent": {
+      "version": "4.1.16",
+      "resolved": "https://registry.npmjs.org/@types/superagent/-/superagent-4.1.16.tgz",
+      "integrity": "sha512-tLfnlJf6A5mB6ddqF159GqcDizfzbMUB1/DeT59/wBNqzRTNNKsaw79A/1TZ84X+f/EwWH8FeuSkjlCLyqS/zQ==",
+      "dependencies": {
+        "@types/cookiejar": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/supertest": {
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/@types/supertest/-/supertest-2.0.12.tgz",
+      "integrity": "sha512-X3HPWTwXRerBZS7Mo1k6vMVR1Z6zmJcDVn5O/31whe0tnjE4te6ZJSJGq1RiqHPjzPdMTfjCFogDJmwng9xHaQ==",
+      "dependencies": {
+        "@types/superagent": "*"
+      }
     },
     "node_modules/@types/yargs": {
       "version": "17.0.18",
@@ -2939,6 +2963,16 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg=="
+    },
+    "node_modules/asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA=="
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "node_modules/babel-jest": {
       "version": "29.3.1",
@@ -3457,6 +3491,22 @@
       "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
       "dev": true
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/component-emitter": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
+      "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg=="
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -3499,6 +3549,11 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ=="
+    },
+    "node_modules/cookiejar": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.3.tgz",
+      "integrity": "sha512-JxbCBUdrfr6AQjOXrxoTvAMJO4HBTUIlBzslcJPAz+/KT8yk53fXun51u+RenNYvad/+Vc2DIz5o9UxlCDymFQ=="
     },
     "node_modules/core-js-compat": {
       "version": "3.27.1",
@@ -3562,6 +3617,14 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -3588,6 +3651,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/dezalgo": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.4.tgz",
+      "integrity": "sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==",
+      "dependencies": {
+        "asap": "^2.0.0",
+        "wrappy": "1"
+      }
+    },
     "node_modules/diff-sequences": {
       "version": "29.3.1",
       "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.3.1.tgz",
@@ -3606,6 +3678,14 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.0.3",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.3.tgz",
+      "integrity": "sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ==",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/ecdsa-sig-formatter": {
@@ -4148,6 +4228,11 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="
     },
+    "node_modules/fast-safe-stringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA=="
+    },
     "node_modules/fastq": {
       "version": "1.14.0",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.14.0.tgz",
@@ -4247,6 +4332,33 @@
       "version": "3.2.7",
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.7.tgz",
       "integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ=="
+    },
+    "node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/formidable": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-2.1.1.tgz",
+      "integrity": "sha512-0EcS9wCFEzLvfiks7omJ+SiYJAiD+TzK4Pcw1UlUoGnhUxDcMKjt0P7x8wEb0u6OHu8Nb98WG3nxtlF5C7bvUQ==",
+      "dependencies": {
+        "dezalgo": "^1.0.4",
+        "hexoid": "^1.0.0",
+        "once": "^1.4.0",
+        "qs": "^6.11.0"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/tunnckoCore/commissions"
+      }
     },
     "node_modules/forwarded": {
       "version": "0.2.0",
@@ -4419,6 +4531,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hexoid": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/hexoid/-/hexoid-1.0.0.tgz",
+      "integrity": "sha512-QFLV0taWQOZtvIRIAdBChesmogZrtuXvVWsFHZTk2SU+anspqZ2vMnoLg7IE1+Uk16N19APic1BuF8bC8c2m5g==",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/html-escaper": {
@@ -7651,6 +7771,79 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/superagent": {
+      "version": "8.0.6",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-8.0.6.tgz",
+      "integrity": "sha512-HqSe6DSIh3hEn6cJvCkaM1BLi466f1LHi4yubR0tpewlMpk4RUFFy35bKz8SsPBwYfIIJy5eclp+3tCYAuX0bw==",
+      "dependencies": {
+        "component-emitter": "^1.3.0",
+        "cookiejar": "^2.1.3",
+        "debug": "^4.3.4",
+        "fast-safe-stringify": "^2.1.1",
+        "form-data": "^4.0.0",
+        "formidable": "^2.1.1",
+        "methods": "^1.1.2",
+        "mime": "2.6.0",
+        "qs": "^6.11.0",
+        "semver": "^7.3.8"
+      },
+      "engines": {
+        "node": ">=6.4.0 <13 || >=14"
+      }
+    },
+    "node_modules/superagent/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/superagent/node_modules/mime": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/superagent/node_modules/semver": {
+      "version": "7.3.8",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/superagent/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+    },
+    "node_modules/supertest": {
+      "version": "6.3.3",
+      "resolved": "https://registry.npmjs.org/supertest/-/supertest-6.3.3.tgz",
+      "integrity": "sha512-EMCG6G8gDu5qEqRQ3JjjPs6+FYT1a7Hv5ApHvtSghmOFJYtsU5S+pSb6Y2EUeCEY3CmEL3mmQ8YWlPOzQomabA==",
+      "dependencies": {
+        "methods": "^1.1.2",
+        "superagent": "^8.0.5"
+      },
+      "engines": {
+        "node": ">=6.4.0"
+      }
+    },
     "node_modules/supports-color": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
@@ -10062,6 +10255,11 @@
         "@types/node": "*"
       }
     },
+    "@types/cookiejar": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@types/cookiejar/-/cookiejar-2.1.2.tgz",
+      "integrity": "sha512-t73xJJrvdTjXrn4jLS9VSGRbz0nUY3cl2DMGDU48lKl+HR9dbbjW2A9r3g40VA++mQpy6uuHg33gy7du2BKpog=="
+    },
     "@types/express": {
       "version": "4.17.15",
       "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.15.tgz",
@@ -10155,8 +10353,7 @@
     "@types/node": {
       "version": "18.11.18",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.18.tgz",
-      "integrity": "sha512-DHQpWGjyQKSHj3ebjFI/wRKcqQcdR+MoFBygntYOZytCqNfkd2ZC4ARDJ2DQqhjH5p85Nnd3jhUJIXrszFX/JA==",
-      "dev": true
+      "integrity": "sha512-DHQpWGjyQKSHj3ebjFI/wRKcqQcdR+MoFBygntYOZytCqNfkd2ZC4ARDJ2DQqhjH5p85Nnd3jhUJIXrszFX/JA=="
     },
     "@types/prettier": {
       "version": "2.7.2",
@@ -10191,6 +10388,23 @@
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz",
       "integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==",
       "dev": true
+    },
+    "@types/superagent": {
+      "version": "4.1.16",
+      "resolved": "https://registry.npmjs.org/@types/superagent/-/superagent-4.1.16.tgz",
+      "integrity": "sha512-tLfnlJf6A5mB6ddqF159GqcDizfzbMUB1/DeT59/wBNqzRTNNKsaw79A/1TZ84X+f/EwWH8FeuSkjlCLyqS/zQ==",
+      "requires": {
+        "@types/cookiejar": "*",
+        "@types/node": "*"
+      }
+    },
+    "@types/supertest": {
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/@types/supertest/-/supertest-2.0.12.tgz",
+      "integrity": "sha512-X3HPWTwXRerBZS7Mo1k6vMVR1Z6zmJcDVn5O/31whe0tnjE4te6ZJSJGq1RiqHPjzPdMTfjCFogDJmwng9xHaQ==",
+      "requires": {
+        "@types/superagent": "*"
+      }
     },
     "@types/yargs": {
       "version": "17.0.18",
@@ -10290,6 +10504,16 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg=="
+    },
+    "asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA=="
+    },
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "babel-jest": {
       "version": "29.3.1",
@@ -10676,6 +10900,19 @@
       "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
       "dev": true
     },
+    "combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "requires": {
+        "delayed-stream": "~1.0.0"
+      }
+    },
+    "component-emitter": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
+      "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg=="
+    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -10709,6 +10946,11 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ=="
+    },
+    "cookiejar": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.3.tgz",
+      "integrity": "sha512-JxbCBUdrfr6AQjOXrxoTvAMJO4HBTUIlBzslcJPAz+/KT8yk53fXun51u+RenNYvad/+Vc2DIz5o9UxlCDymFQ=="
     },
     "core-js-compat": {
       "version": "3.27.1",
@@ -10754,6 +10996,11 @@
       "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==",
       "dev": true
     },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="
+    },
     "depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -10770,6 +11017,15 @@
       "integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
       "dev": true
     },
+    "dezalgo": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.4.tgz",
+      "integrity": "sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==",
+      "requires": {
+        "asap": "^2.0.0",
+        "wrappy": "1"
+      }
+    },
     "diff-sequences": {
       "version": "29.3.1",
       "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.3.1.tgz",
@@ -10783,6 +11039,11 @@
       "requires": {
         "esutils": "^2.0.2"
       }
+    },
+    "dotenv": {
+      "version": "16.0.3",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.3.tgz",
+      "integrity": "sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ=="
     },
     "ecdsa-sig-formatter": {
       "version": "1.0.11",
@@ -11182,6 +11443,11 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="
     },
+    "fast-safe-stringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA=="
+    },
     "fastq": {
       "version": "1.14.0",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.14.0.tgz",
@@ -11268,6 +11534,27 @@
       "version": "3.2.7",
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.7.tgz",
       "integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ=="
+    },
+    "form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "requires": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      }
+    },
+    "formidable": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-2.1.1.tgz",
+      "integrity": "sha512-0EcS9wCFEzLvfiks7omJ+SiYJAiD+TzK4Pcw1UlUoGnhUxDcMKjt0P7x8wEb0u6OHu8Nb98WG3nxtlF5C7bvUQ==",
+      "requires": {
+        "dezalgo": "^1.0.4",
+        "hexoid": "^1.0.0",
+        "once": "^1.4.0",
+        "qs": "^6.11.0"
+      }
     },
     "forwarded": {
       "version": "0.2.0",
@@ -11386,6 +11673,11 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
       "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A=="
+    },
+    "hexoid": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/hexoid/-/hexoid-1.0.0.tgz",
+      "integrity": "sha512-QFLV0taWQOZtvIRIAdBChesmogZrtuXvVWsFHZTk2SU+anspqZ2vMnoLg7IE1+Uk16N19APic1BuF8bC8c2m5g=="
     },
     "html-escaper": {
       "version": "2.0.2",
@@ -13776,6 +14068,60 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
       "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig=="
+    },
+    "superagent": {
+      "version": "8.0.6",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-8.0.6.tgz",
+      "integrity": "sha512-HqSe6DSIh3hEn6cJvCkaM1BLi466f1LHi4yubR0tpewlMpk4RUFFy35bKz8SsPBwYfIIJy5eclp+3tCYAuX0bw==",
+      "requires": {
+        "component-emitter": "^1.3.0",
+        "cookiejar": "^2.1.3",
+        "debug": "^4.3.4",
+        "fast-safe-stringify": "^2.1.1",
+        "form-data": "^4.0.0",
+        "formidable": "^2.1.1",
+        "methods": "^1.1.2",
+        "mime": "2.6.0",
+        "qs": "^6.11.0",
+        "semver": "^7.3.8"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "mime": {
+          "version": "2.6.0",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+          "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg=="
+        },
+        "semver": {
+          "version": "7.3.8",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+          "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        },
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+        }
+      }
+    },
+    "supertest": {
+      "version": "6.3.3",
+      "resolved": "https://registry.npmjs.org/supertest/-/supertest-6.3.3.tgz",
+      "integrity": "sha512-EMCG6G8gDu5qEqRQ3JjjPs6+FYT1a7Hv5ApHvtSghmOFJYtsU5S+pSb6Y2EUeCEY3CmEL3mmQ8YWlPOzQomabA==",
+      "requires": {
+        "methods": "^1.1.2",
+        "superagent": "^8.0.5"
+      }
     },
     "supports-color": {
       "version": "5.5.0",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -8,25 +8,26 @@ datasource db {
 }
 
 model aloneOption {
-  id           Int        @id(map: "AloneOption_pkey") @default(autoincrement())
-  worryAloneId Int
-  title        String     @db.VarChar(200)
-  advantage    String?    @db.VarChar(50)
-  disadvantage String?    @db.VarChar(200)
-  image        String?    @db.VarChar(100)
-  isSelected   Boolean?   @default(false)
-  worryAlone   worryAlone @relation(fields: [worryAloneId], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "worryAloneId")
+  id                                              Int          @id(map: "AloneOption_pkey") @unique @default(autoincrement())
+  worryAloneId                                    Int
+  title                                           String       @db.VarChar(200)
+  advantage                                       String?      @db.VarChar(50)
+  disadvantage                                    String?      @db.VarChar(200)
+  image                                           String?      @db.VarChar(100)
+  isSelected                                      Boolean?     @default(false)
+  worryAlone_aloneOption_worryAloneIdToworryAlone worryAlone   @relation("aloneOption_worryAloneIdToworryAlone", fields: [worryAloneId], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "worryAloneId")
+  worryAlone_worryAlone_finalOptionToaloneOption  worryAlone[] @relation("worryAlone_finalOptionToaloneOption")
 }
 
 model category {
-  id         Int          @id @default(autoincrement())
+  id         Int          @id @unique @default(autoincrement())
   name       String       @db.VarChar(50)
   worryAlone worryAlone[]
   worryWith  worryWith[]
 }
 
 model comment {
-  id          Int       @id(map: "Comment_pkey") @default(autoincrement())
+  id          Int       @id(map: "Comment_pkey") @unique @default(autoincrement())
   nickName    String    @db.VarChar(200)
   content     String    @db.VarChar(200)
   createdAt   DateTime  @default(now()) @db.Timestamp(6)
@@ -36,7 +37,7 @@ model comment {
 }
 
 model quickWorry {
-  id           Int            @id @default(autoincrement())
+  id           Int            @id @unique @default(autoincrement())
   title        String         @db.VarChar(60)
   createdAt    DateTime       @default(now()) @db.Timestamp(6)
   updatedAt    DateTime       @default(now()) @db.Timestamp(6)
@@ -54,7 +55,7 @@ model randomAnswer {
 }
 
 model user {
-  id           Int          @id @default(autoincrement())
+  id           Int          @id @unique @default(autoincrement())
   votes        Int[]        @default([])
   votedWorries Int[]        @default([])
   profileImage String       @db.VarChar(200)
@@ -69,55 +70,56 @@ model user {
 }
 
 model vote {
-  id         Int        @unique @default(autoincrement())
+  id         Int        @id @unique @default(autoincrement())
   userId     Int
-  optionId   Int        @id
+  optionId   Int
   withOption withOption @relation(fields: [optionId], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "optionId")
   user       user       @relation(fields: [userId], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "userId")
 }
 
 model withOption {
-  id                                          Int         @id @default(autoincrement())
+  id                                          Int         @id @unique @default(autoincrement())
   worryWithId                                 Int
   title                                       String      @db.VarChar(200)
   advantage                                   String?     @db.VarChar(50)
   disadvantage                                String?     @db.VarChar(200)
   image                                       String?     @db.VarChar(300)
   hasImage                                    Boolean     @default(false)
-  vote                                        vote?
-  worryWith                                   worryWith   @relation(fields: [worryWithId], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "worryWithId")
+  vote                                        vote[]
+  worryWith_withOption_worryWithIdToworryWith worryWith   @relation("withOption_worryWithIdToworryWith", fields: [worryWithId], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "worryWithId")
   worryWith_worryWith_finalOptionTowithOption worryWith[] @relation("worryWith_finalOptionTowithOption")
 }
 
 model worryAlone {
-  id          Int           @id @default(autoincrement())
-  title       String        @db.VarChar(60)
-  content     String        @db.VarChar(4000)
-  finalOption Int?
-  isVoted     Boolean       @default(false)
-  createdAt   DateTime      @default(now()) @db.Timestamp(6)
-  updatedAt   DateTime      @default(now()) @db.Timestamp(6)
-  categoryId  Int
-  userId      Int?
-  aloneOption aloneOption[]
-  category    category      @relation(fields: [categoryId], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "categoryId")
-  user        user?         @relation(fields: [userId], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "userId")
+  id                                               Int           @id @unique @default(autoincrement())
+  title                                            String        @db.VarChar(60)
+  content                                          String        @db.VarChar(4000)
+  finalOption                                      Int?
+  createdAt                                        DateTime      @default(now()) @db.Timestamp(6)
+  updatedAt                                        DateTime      @default(now()) @db.Timestamp(6)
+  categoryId                                       Int
+  userId                                           Int
+  aloneOption_aloneOption_worryAloneIdToworryAlone aloneOption[] @relation("aloneOption_worryAloneIdToworryAlone")
+  category                                         category      @relation(fields: [categoryId], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "categoryId")
+  aloneOption_worryAlone_finalOptionToaloneOption  aloneOption?  @relation("worryAlone_finalOptionToaloneOption", fields: [finalOption], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "finalOption")
+  user                                             user          @relation(fields: [userId], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "userId")
 }
 
 model worryWith {
-  id                                           Int          @id @default(autoincrement())
+  id                                           Int          @id @unique @default(autoincrement())
   title                                        String       @db.VarChar(60)
   content                                      String       @db.VarChar(4000)
   finalOption                                  Int?
-  isVoted                                      Boolean      @default(false)
   createdAt                                    DateTime     @default(now()) @db.Timestamp(6)
   updatedAt                                    DateTime?    @default(now()) @db.Timestamp(6)
   categoryId                                   Int
   userId                                       Int
   commentOn                                    Boolean      @default(false)
   commentCount                                 Int          @default(0)
+  isAuthor                                     Boolean      @default(false)
+  isVoted                                      Boolean      @default(false)
   comment                                      comment[]
-  withOption                                   withOption[]
+  withOption                                   withOption[] @relation("withOption_worryWithIdToworryWith")
   category                                     category     @relation(fields: [categoryId], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "categoryId")
   withOption_worryWith_finalOptionTowithOption withOption?  @relation("worryWith_finalOptionTowithOption", fields: [finalOption], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "finalOption")
   user                                         user         @relation(fields: [userId], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "userId")

--- a/src/constants/responseMessage.ts
+++ b/src/constants/responseMessage.ts
@@ -30,7 +30,7 @@ export default {
   READ_WORRY_FAIL: "고민글 조회 실패",
 
   //카테고리
-  READ_CATEGORY_FAIL: "없는 카테고리번호 입니다.",
+  READ_CATEGORY_FAIL: "카테고리 조회 실패",
 
   // 토큰
   CREATE_TOKEN_SUCCESS: "토큰 재발급 성공",

--- a/src/constants/responseMessage.ts
+++ b/src/constants/responseMessage.ts
@@ -14,7 +14,7 @@ export default {
 
   // 유저
   READ_USER_SUCCESS: "유저 조회 성공",
-  READ_USER_FAIL: "유저 조회 성공",
+  READ_USER_FAIL: "유저 조회 실패",
   READ_ALL_USERS_SUCCESS: "모든 유저 조회 성공",
   READ_ALL_USERS_FAIL: "모든 유저 조회 실패",
   UPDATE_USER_SUCCESS: "유저 수정 성공",
@@ -22,6 +22,15 @@ export default {
   DELETE_USER_SUCCESS: "유저 탈퇴 성공",
   DELETE_USER_FAIL: "유저 탈퇴 실패",
   NO_USER: "탈퇴했거나 가입하지 않은 유저입니다.",
+
+  // 고민글 
+  READ_WORRYLIST_SUCCESS: "고민글 조회 성공",
+  READ_WORRYLIST_FAIL: "고민글 조회 실패",
+  READ_WORRY_SUCCESS: "고민글 조회 성공",
+  READ_WORRY_FAIL: "고민글 조회 실패",
+
+  //카테고리
+  READ_CATEGORY_FAIL: "없는 카테고리번호 입니다.",
 
   // 토큰
   CREATE_TOKEN_SUCCESS: "토큰 재발급 성공",

--- a/src/controller/index.ts
+++ b/src/controller/index.ts
@@ -1,3 +1,4 @@
 import worryWithController from './worryWithController';
 
 export { worryWithController };
+export { default as worryController } from './worryController';

--- a/src/controller/worryController.ts
+++ b/src/controller/worryController.ts
@@ -5,7 +5,7 @@ import { ClientException } from "../common/error/exceptions/customExceptions";
 import statusCode from "../constants/statusCode";
 import { worryService } from "../service";
 
-const getWorryListByCategory = async (req: Request, res: Response) => {
+const findWorryListByCategory = async (req: Request, res: Response, next: NextFunction) => {
     try {
         const { categoryId } = req.params;
 
@@ -13,7 +13,7 @@ const getWorryListByCategory = async (req: Request, res: Response) => {
             throw new ClientException("필요한 Param 값이 없습니다.");
         }
 
-        const data = await worryService.getWorryListByCategoryId(+categoryId);
+        const data = await worryService.findWorryListByCategoryId(+categoryId);
 
         return res.status(sc.OK).send(success(statusCode.OK, rm.READ_WORRYLIST_SUCCESS, data));
 
@@ -22,4 +22,4 @@ const getWorryListByCategory = async (req: Request, res: Response) => {
     }
 };
 
-export default { getWorryListByCategory };
+export default { findWorryListByCategory };

--- a/src/controller/worryController.ts
+++ b/src/controller/worryController.ts
@@ -1,4 +1,4 @@
-import { Request, Response } from "express";
+import { NextFunction, Request, Response } from "express";
 import { fail, success } from "../constants/response";
 import { rm, sc } from "../constants";
 import { ClientException } from "../common/error/exceptions/customExceptions";
@@ -18,7 +18,7 @@ const getWorryListByCategory = async (req: Request, res: Response) => {
         return res.status(sc.OK).send(success(statusCode.OK, rm.READ_WORRYLIST_SUCCESS, data));
 
     } catch (error) {
-        return res.status(sc.BAD_REQUEST).send(fail(sc.BAD_REQUEST, rm.READ_WORRYLIST_FAIL));
+        next(error);
     }
 };
 

--- a/src/controller/worryController.ts
+++ b/src/controller/worryController.ts
@@ -1,0 +1,25 @@
+import { Request, Response } from "express";
+import { fail, success } from "../constants/response";
+import { rm, sc } from "../constants";
+import { ClientException } from "../common/error/exceptions/customExceptions";
+import statusCode from "../constants/statusCode";
+import { worryService } from "../service";
+
+const getWorryListByCategory = async (req: Request, res: Response) => {
+    try {
+        const { categoryId } = req.params;
+
+        if (!categoryId) {
+            throw new ClientException("필요한 Param 값이 없습니다.");
+        }
+
+        const data = await worryService.getWorryListByCategoryId(+categoryId);
+
+        return res.status(sc.OK).send(success(statusCode.OK, rm.READ_WORRYLIST_SUCCESS, data));
+
+    } catch (error) {
+        return res.status(sc.BAD_REQUEST).send(fail(sc.BAD_REQUEST, rm.READ_WORRYLIST_FAIL));
+    }
+};
+
+export default { getWorryListByCategory };

--- a/src/repository/categoryRepository.ts
+++ b/src/repository/categoryRepository.ts
@@ -1,0 +1,13 @@
+import { PrismaClient, category } from "@prisma/client";
+import prisma from "./prismaClient";
+
+const getCategoryId = async () => {
+    const categories = await prisma.category.findMany({
+        select: {
+            id: true
+        },
+    });
+    return categories;
+};
+
+export default { getCategoryId };

--- a/src/repository/index.ts
+++ b/src/repository/index.ts
@@ -1,4 +1,6 @@
 import worryWithRepository from './worryWithRepository';
 import withOptionRepository from './withOptionRepository';
+import categoryRepository from './categoryRepository';
+import worryRepository from './worryRepository';
 
-export { worryWithRepository, withOptionRepository };
+export { worryWithRepository, withOptionRepository, categoryRepository, worryRepository };

--- a/src/repository/worryRepository.ts
+++ b/src/repository/worryRepository.ts
@@ -2,7 +2,7 @@ import { PrismaClient, worryWith } from "@prisma/client";
 import prisma from "./prismaClient";
 
 // 카테고리 해당 id 값에 대해서
-const getWorryListByCategoryId = async (categoryId?: number) => {
+const findWorryListByCategoryId = async (categoryId?: number) => {
     const worries = await prisma.worryWith.findMany({
         where: {
             categoryId: categoryId
@@ -44,7 +44,7 @@ const getWorryListByCategoryId = async (categoryId?: number) => {
 }
 
 // 카테고리 : 전체 
-const getWorries = async () => {
+const findWorries = async () => {
 
     const worries = await prisma.worryWith.findMany({
         include: {
@@ -83,4 +83,4 @@ const getWorries = async () => {
     return worryResponse;
 }
 
-export default { getWorryListByCategoryId, getWorries };
+export default { findWorryListByCategoryId, findWorries };

--- a/src/repository/worryRepository.ts
+++ b/src/repository/worryRepository.ts
@@ -1,0 +1,86 @@
+import { PrismaClient, worryWith } from "@prisma/client";
+import prisma from "./prismaClient";
+
+// 카테고리 해당 id 값에 대해서
+const getWorryListByCategoryId = async (categoryId?: number) => {
+    const worries = await prisma.worryWith.findMany({
+        where: {
+            categoryId: categoryId
+        },
+        include: {
+            category: true,
+            withOption: {
+                select: {
+                    id: true,
+                    worryWithId: true,
+                    title: true,
+                    image: true,
+                    hasImage: true
+                }
+            },
+        },
+    });
+
+    // response객체를 flattening을 해주는 작업
+    const worryResponse = await Promise.all(
+        worries.map(async (worryWith: any) => {
+            const data = {
+                worryId: worryWith.id,
+                title: worryWith.title,
+                content: worryWith.content,
+                createdAt: worryWith.createdAt,
+                category: worryWith.category.name,
+                selectedOptionId: worryWith.finalOption,
+                isAuthor: worryWith.isAuthor,
+                isVoted: worryWith.isVoted,
+                commentOn: worryWith.commentOn,
+                commentCount: worryWith.commentCount,
+                option: worryWith.withOption
+            };
+            return data;
+        }),
+    );
+    return worryResponse;
+}
+
+// 카테고리 : 전체 
+const getWorries = async () => {
+
+    const worries = await prisma.worryWith.findMany({
+        include: {
+            category: true,
+            withOption: {
+                select: {
+                    id: true,
+                    worryWithId: true,
+                    title: true,
+                    image: true,
+                    hasImage: true
+                }
+            },
+        },
+    });
+
+    // response객체를 flattening을 해주는 작업
+    const worryResponse = await Promise.all(
+        worries.map(async (worryWith: any) => {
+            const data = {
+                worryId: worryWith.id,
+                title: worryWith.title,
+                content: worryWith.content,
+                createdAt: worryWith.createdAt,
+                category: worryWith.category.name,
+                selectedOptionId: worryWith.finalOption,
+                isAuthor: worryWith.isAuthor,
+                isVoted: worryWith.isVoted,
+                commentOn: worryWith.commentOn,
+                commentCount: worryWith.commentCount,
+                option: worryWith.withOption
+            };
+            return data;
+        }),
+    );
+    return worryResponse;
+}
+
+export default { getWorryListByCategoryId, getWorries };

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -1,8 +1,10 @@
 import { Router } from "express";
+import worryRouter from "./worryRouter";
 import worryWithRouter from './worryWithRouter';
 
 const router: Router = Router();
 
+router.use("/worry", worryRouter);
 router.use('/worry/with', worryWithRouter);
 
 export default router;

--- a/src/router/worryRouter.ts
+++ b/src/router/worryRouter.ts
@@ -3,6 +3,6 @@ import { worryController } from "../controller";
 
 const worryRouter: Router = Router();
 
-worryRouter.get("/:categoryId", worryController.getWorryListByCategory);
+worryRouter.get("/:categoryId", worryController.findWorryListByCategory);
 
 export default worryRouter;

--- a/src/router/worryRouter.ts
+++ b/src/router/worryRouter.ts
@@ -1,0 +1,8 @@
+import { Router } from "express";
+import { worryController } from "../controller";
+
+const worryRouter: Router = Router();
+
+worryRouter.get("/:categoryId", worryController.getWorryListByCategory);
+
+export default worryRouter;

--- a/src/service/index.ts
+++ b/src/service/index.ts
@@ -1,3 +1,4 @@
 import worryWithService from "./worryWithService";
 
 export { worryWithService };
+export { default as worryService } from "./worryService";

--- a/src/service/worryService.ts
+++ b/src/service/worryService.ts
@@ -1,0 +1,25 @@
+import { ClientException } from "../common/error/exceptions/customExceptions";
+import statusCode from "../constants/statusCode";
+import { worryRepository, categoryRepository } from "../repository"
+
+const getWorryListByCategoryId = async (categoryId: number) => {
+    const worryWithList = (categoryId == 0) ? await worryRepository.getWorries() : await worryRepository.getWorryListByCategoryId(categoryId);
+
+    const categoryList = await categoryRepository.getCategoryId();
+
+    if (!worryWithList) {
+        throw new ClientException("해당 게시글이 없습니다.");
+    }
+
+    if (!categoryList) {
+        throw new ClientException("카테고리가 없습니다.");
+    }
+
+    if (categoryList.length == 0 || +categoryId > categoryList.length || +categoryId < 0) {
+        throw new ClientException("해당 카테고리의 글이 없습니다.");
+    }
+
+    return worryWithList;
+};
+
+export default { getWorryListByCategoryId };

--- a/src/service/worryService.ts
+++ b/src/service/worryService.ts
@@ -4,6 +4,7 @@ import { worryRepository, categoryRepository } from "../repository"
 
 const isTotal = (categoryId: number): boolean => categoryId === 0;
 
+const findWorryListByCategoryId = async (categoryId: number) => {
     const worryWithList = isTotal(categoryId) ? await worryRepository.findWorries() : await worryRepository.findWorryListByCategoryId(categoryId);
 
     const categoryList = await categoryRepository.getCategoryId();
@@ -19,4 +20,4 @@ const isTotal = (categoryId: number): boolean => categoryId === 0;
     return worryWithList;
 };
 
-export default { getWorryListByCategoryId };
+export default { findWorryListByCategoryId };

--- a/src/service/worryService.ts
+++ b/src/service/worryService.ts
@@ -2,21 +2,18 @@ import { ClientException } from "../common/error/exceptions/customExceptions";
 import statusCode from "../constants/statusCode";
 import { worryRepository, categoryRepository } from "../repository"
 
-const getWorryListByCategoryId = async (categoryId: number) => {
-    const worryWithList = (categoryId == 0) ? await worryRepository.getWorries() : await worryRepository.getWorryListByCategoryId(categoryId);
+const isTotal = (categoryId: number): boolean => categoryId === 0;
+
+    const worryWithList = isTotal(categoryId) ? await worryRepository.findWorries() : await worryRepository.findWorryListByCategoryId(categoryId);
 
     const categoryList = await categoryRepository.getCategoryId();
-
-    if (!worryWithList) {
-        throw new ClientException("해당 게시글이 없습니다.");
-    }
 
     if (!categoryList) {
         throw new ClientException("카테고리가 없습니다.");
     }
 
-    if (categoryList.length == 0 || +categoryId > categoryList.length || +categoryId < 0) {
-        throw new ClientException("해당 카테고리의 글이 없습니다.");
+    if (+categoryId > categoryList.length || +categoryId < 0) {
+        throw new ClientException("없는 카테고리입니다");
     }
 
     return worryWithList;

--- a/test/controller/worryController.spec.ts
+++ b/test/controller/worryController.spec.ts
@@ -1,0 +1,17 @@
+import request from 'supertest';
+import app from '../testApp';
+
+describe("GET /worry/:categoryId", () => {
+    it("올바른 응답", async () => {
+        const response = await request(app)
+            .get("/api/worry/1")
+        expect(response.statusCode).toBe(200);
+        expect(response.body.message).toEqual("고민글 조회 성공");
+    })
+    it("잘못된 응답", async () => {
+        const response = await request(app)
+            .get("/api/worry/10000")
+        expect(response.statusCode).toBe(400);
+        expect(response.body.message).toEqual("고민글 조회 실패");
+    })
+})

--- a/test/controller/worryController.spec.ts
+++ b/test/controller/worryController.spec.ts
@@ -4,14 +4,258 @@ import app from '../testApp';
 describe("GET /worry/:categoryId", () => {
     it("올바른 응답", async () => {
         const response = await request(app)
-            .get("/api/worry/1")
+            .get("/api/worry/0")
         expect(response.statusCode).toBe(200);
         expect(response.body.message).toEqual("고민글 조회 성공");
+        // expect(response.body).toMatchObject({
+        //     "status": 200,
+        //     "success": true,
+        //     "message": "고민글 조회 성공",
+        //     "data": [
+        //         {
+        //             "worryId": 4,
+        //             "title": "글자수 제한은 공백 포함 28자 글자수 제한은 공백",
+        //             "content": "1. 동해물과 백두산이 마르고 닳도록 하느님이 보우하사 우리나라 만세 무궁화 삼천리 화려 강산 대한 사람 대한으로 길이 보전하세 2. 남산 위에 저 소나무 철갑을 두른 듯 바람 서리 불변함은 우리 기상일세 무궁화 삼천리 화려 강산 대한 사람 대한으로 길이 보전하세 3. 가을 하늘 공활한데 ...",
+        //             "createdAt": "2023-01-04T18:02:16.820Z",
+        //             "category": "일상",
+        //             "selectedOptionId": 4,
+        //             "isAuthor": false,
+        //             "isVoted": false,
+        //             "commentOn": false,
+        //             "commentCount": 0,
+        //             "option": [
+        //                 {
+        //                     "id": 5,
+        //                     "worryWithId": 4,
+        //                     "title": "sss",
+        //                     "image": null,
+        //                     "hasImage": false
+        //                 },
+        //                 {
+        //                     "id": 6,
+        //                     "worryWithId": 4,
+        //                     "title": "dffff",
+        //                     "image": null,
+        //                     "hasImage": false
+        //                 }
+        //             ]
+        //         },
+        //         {
+        //             "worryId": 3,
+        //             "title": "fsdfdsfffdfdsfdsfds",
+        //             "content": "dsfdsfdsff",
+        //             "createdAt": "2023-01-05T03:00:50.000Z",
+        //             "category": "일상",
+        //             "selectedOptionId": 3,
+        //             "isAuthor": false,
+        //             "isVoted": false,
+        //             "commentOn": true,
+        //             "commentCount": 20,
+        //             "option": [
+        //                 {
+        //                     "id": 3,
+        //                     "worryWithId": 3,
+        //                     "title": "s",
+        //                     "image": null,
+        //                     "hasImage": false
+        //                 },
+        //                 {
+        //                     "id": 4,
+        //                     "worryWithId": 3,
+        //                     "title": "a",
+        //                     "image": null,
+        //                     "hasImage": false
+        //                 }
+        //             ]
+        //         },
+        //         {
+        //             "worryId": 5,
+        //             "title": "ddd",
+        //             "content": "fsdfds",
+        //             "createdAt": "2023-01-05T11:40:00.838Z",
+        //             "category": "연애",
+        //             "selectedOptionId": null,
+        //             "isAuthor": false,
+        //             "isVoted": false,
+        //             "commentOn": false,
+        //             "commentCount": 0,
+        //             "option": [
+        //                 {
+        //                     "id": 7,
+        //                     "worryWithId": 5,
+        //                     "title": "s",
+        //                     "image": null,
+        //                     "hasImage": false
+        //                 },
+        //                 {
+        //                     "id": 8,
+        //                     "worryWithId": 5,
+        //                     "title": "s",
+        //                     "image": null,
+        //                     "hasImage": false
+        //                 }
+        //             ]
+        //         },
+        //         {
+        //             "worryId": 6,
+        //             "title": "sdfsdfsdf",
+        //             "content": "sdfsdf",
+        //             "createdAt": "2023-01-05T11:40:00.838Z",
+        //             "category": "연애",
+        //             "selectedOptionId": null,
+        //             "isAuthor": false,
+        //             "isVoted": false,
+        //             "commentOn": false,
+        //             "commentCount": 0,
+        //             "option": [
+        //                 {
+        //                     "id": 9,
+        //                     "worryWithId": 6,
+        //                     "title": "aa",
+        //                     "image": null,
+        //                     "hasImage": false
+        //                 },
+        //                 {
+        //                     "id": 10,
+        //                     "worryWithId": 6,
+        //                     "title": "ss",
+        //                     "image": null,
+        //                     "hasImage": false
+        //                 }
+        //             ]
+        //         },
+        //         {
+        //             "worryId": 7,
+        //             "title": "sdf",
+        //             "content": "dd",
+        //             "createdAt": "2023-01-05T11:40:34.383Z",
+        //             "category": "패션/뷰티",
+        //             "selectedOptionId": null,
+        //             "isAuthor": false,
+        //             "isVoted": false,
+        //             "commentOn": false,
+        //             "commentCount": 0,
+        //             "option": [
+        //                 {
+        //                     "id": 11,
+        //                     "worryWithId": 7,
+        //                     "title": "s",
+        //                     "image": null,
+        //                     "hasImage": false
+        //                 },
+        //                 {
+        //                     "id": 12,
+        //                     "worryWithId": 7,
+        //                     "title": "s",
+        //                     "image": null,
+        //                     "hasImage": false
+        //                 }
+        //             ]
+        //         },
+        //         {
+        //             "worryId": 8,
+        //             "title": "aa",
+        //             "content": "dd",
+        //             "createdAt": "2023-01-05T11:40:34.383Z",
+        //             "category": "패션/뷰티",
+        //             "selectedOptionId": null,
+        //             "isAuthor": false,
+        //             "isVoted": false,
+        //             "commentOn": false,
+        //             "commentCount": 0,
+        //             "option": [
+        //                 {
+        //                     "id": 13,
+        //                     "worryWithId": 8,
+        //                     "title": "s",
+        //                     "image": null,
+        //                     "hasImage": false
+        //                 },
+        //                 {
+        //                     "id": 14,
+        //                     "worryWithId": 8,
+        //                     "title": "s",
+        //                     "image": null,
+        //                     "hasImage": false
+        //                 }
+        //             ]
+        //         },
+        //         {
+        //             "worryId": 9,
+        //             "title": "aa",
+        //             "content": "dd",
+        //             "createdAt": "2023-01-05T11:40:34.383Z",
+        //             "category": "커리어",
+        //             "selectedOptionId": null,
+        //             "isAuthor": false,
+        //             "isVoted": false,
+        //             "commentOn": false,
+        //             "commentCount": 0,
+        //             "option": [
+        //                 {
+        //                     "id": 15,
+        //                     "worryWithId": 9,
+        //                     "title": "s",
+        //                     "image": null,
+        //                     "hasImage": false
+        //                 },
+        //                 {
+        //                     "id": 16,
+        //                     "worryWithId": 9,
+        //                     "title": "s",
+        //                     "image": null,
+        //                     "hasImage": false
+        //                 }
+        //             ]
+        //         },
+        //         {
+        //             "worryId": 10,
+        //             "title": "aa",
+        //             "content": "dsfdf",
+        //             "createdAt": "2023-01-05T11:40:34.383Z",
+        //             "category": "커리어",
+        //             "selectedOptionId": null,
+        //             "isAuthor": false,
+        //             "isVoted": false,
+        //             "commentOn": false,
+        //             "commentCount": 0,
+        //             "option": []
+        //         },
+        //         {
+        //             "worryId": 2,
+        //             "title": "함께 고민 더미를 만들까요 말까요?",
+        //             "content": "만들지 말지 고민입니다.",
+        //             "createdAt": "2023-01-04T08:02:35.300Z",
+        //             "category": "일상",
+        //             "selectedOptionId": 2,
+        //             "isAuthor": false,
+        //             "isVoted": false,
+        //             "commentOn": false,
+        //             "commentCount": 10,
+        //             "option": [
+        //                 {
+        //                     "id": 1,
+        //                     "worryWithId": 2,
+        //                     "title": "올려",
+        //                     "image": null,
+        //                     "hasImage": false
+        //                 },
+        //                 {
+        //                     "id": 2,
+        //                     "worryWithId": 2,
+        //                     "title": "말아",
+        //                     "image": null,
+        //                     "hasImage": false
+        //                 }
+        //             ]
+        //         }
+        //     ]
+        // });
     })
-    it("잘못된 응답", async () => {
+    it("카테고리 번호가 없는 경우", async () => {
         const response = await request(app)
             .get("/api/worry/10000")
         expect(response.statusCode).toBe(400);
-        expect(response.body.message).toEqual("고민글 조회 실패");
+        expect(response.body.message).toEqual("없는 카테고리입니다");
     })
 })


### PR DESCRIPTION
**우선순위**
<!--
D-0 (ASAP)
긴급한 수정사항으로 바로 리뷰해 주세요.
앱의 오류로 인해 장애가 발생하거나, 빌드가 되지 않는 등 긴급 이슈가 발생할 때 사용합니다.
D-N (Within N days)
N일 이내에 리뷰해 주세요
-->

- D-0
- closes: #3 

**변경사항**
- 고민글 전체 조회 구현
- supertest로 API 테스트 파일 생성했습니다.

**유의사항**
responseMessage를 구현하기 위해서, flattening을 하기 위해서 Response메세지 객체를 하나 더 구현했습니다. 
이 부분이 중복적으로 사용되고, DTO 파일을 이용해 구현하는 방법이 있을 것 같은데, 이 부분들을 DTO로 구현할 수 있을까요?

------------------------------------------------------------------------
categoryId가 0번일때는 전체 카테고리 조회인데, 이 부분 구현 부분을 두가지로 나누었는데, 이부분이 맞는지 확신이 서지 않습니다..

worryService.ts 파일의 부분입니다.

```Javascript
const getWorryListByCategoryId = async (categoryId: number) => {
const worryWithList = (categoryId == 0) ? await worryRepository.getWorries() : await worryRepository.getWorryListByCategoryId(categoryId);
```
더 좋은 방안이 있다면 알려주시면 감사하겠습니당 🥰

<!--
- 영향범위
- 중점적으로 pr 리뷰해줬으면 하는 부분
-->

**참조**

- `localhost:3000/api/worry/0` : 전체 카테고리 조회

<img width="704" alt="image" src="https://user-images.githubusercontent.com/78431728/210780923-a14290a9-1daa-4953-9f95-dd70ad42e858.png">

- `localhost:3000/api/worry/1` : 1번째 카테고리 조회

<img width="693" alt="image" src="https://user-images.githubusercontent.com/78431728/210781110-e744d323-1cd5-4c20-bb64-6257d75b4385.png">

- jest 테스트 성공

<img width="674" alt="image" src="https://user-images.githubusercontent.com/78431728/210780338-09b96950-1c26-40a1-aac6-e3f96f2ad1cd.png">
