### PR TITLE
[FEAT] 혼자 고민글 최종 결정하기 API

### DIFF
--- a/src/constants/responseMessage.ts
+++ b/src/constants/responseMessage.ts
@@ -57,4 +57,5 @@ export default {
   // 혼자고민
   CREATE_WORRY_ALONE_ERROR: "혼자고민 업로드 오류",
   CREATE_WORRY_ALONE_SUCCESS: "혼자고민 업로드 성공",
+  CHOOSE_ALONE_OPTION_SUCCESS: "혼자고민 결정하기 성공"
 };

--- a/src/controller/index.ts
+++ b/src/controller/index.ts
@@ -1,6 +1,6 @@
 import worryWithController from './worryWithController';
 import worryAloneController from './worryAloneController';
-import randomController from "./randomController";
+import randomController from './randomController';
 import worryController from "./worryController";
 
 export { worryWithController, worryAloneController, randomController, worryController };

--- a/src/controller/worryAloneController.ts
+++ b/src/controller/worryAloneController.ts
@@ -58,9 +58,25 @@ const getAloneWorry = async (
   }
 };
 
-const worryAloneController = {
-  createAloneWorry,
-  getAloneWorry,
-};
+const patchWorryAlone = async (req: Request, res: Response, next: NextFunction) => {
+    try {
+        const reqValidationResult = validationResult(req);
+        if (!reqValidationResult.isEmpty()) {
+            return res.status(sc.BAD_REQUEST).send(fail(sc.BAD_REQUEST, rm.NULL_VALUE));
+        }
 
-export default worryAloneController;
+        const { worryAloneId, chosenOptionId } = req.body;
+
+        // service - 결정하기
+        res.status(sc.OK).send(success(sc.OK, rm.CHOOSE_ALONE_OPTION_SUCCESS));
+    } catch (error) {
+        next(error);
+    }
+}
+
+
+export default {
+    createAloneWorry,
+    getAloneWorry,
+    patchWorryAlone
+}

--- a/src/controller/worryAloneController.ts
+++ b/src/controller/worryAloneController.ts
@@ -65,9 +65,14 @@ const patchWorryAlone = async (req: Request, res: Response, next: NextFunction) 
             return res.status(sc.BAD_REQUEST).send(fail(sc.BAD_REQUEST, rm.NULL_VALUE));
         }
 
-        const { worryAloneId, chosenOptionId } = req.body;
+        const { userId, worryAloneId, chosenOptionId } = req.body;
 
-        // service - 결정하기
+        await worryAloneService.chooseFinalOption({
+            userId,
+            aloneWorryId: worryAloneId,
+            chosenOptionId,
+        })
+
         res.status(sc.OK).send(success(sc.OK, rm.CHOOSE_ALONE_OPTION_SUCCESS));
     } catch (error) {
         next(error);

--- a/src/interfaces/worryAlone/ChooseAloneWorryDTO.ts
+++ b/src/interfaces/worryAlone/ChooseAloneWorryDTO.ts
@@ -1,0 +1,5 @@
+export default interface ChooseAloneWorryDTO {
+  userId: number;
+  aloneWorryId: number;
+  chosenOptionId: number;
+}

--- a/src/repository/aloneOptionRepository.ts
+++ b/src/repository/aloneOptionRepository.ts
@@ -1,0 +1,11 @@
+import prisma from "./prismaClient";
+
+const findById = async (id: number) => {
+  return await prisma.aloneOption.findUnique({
+    where: { id }
+  });
+}
+
+export default {
+  findById
+};

--- a/src/repository/aloneOptionRepository.ts
+++ b/src/repository/aloneOptionRepository.ts
@@ -15,8 +15,20 @@ const findByIdAndWorryId = async (id: number, worryId: number) => {
   });
 }
 
+const updateIsSelectedById = async (id: number, isSelected: boolean) => {
+  await prisma.aloneOption.update({
+    where: {
+      id
+    },
+    data: {
+      isSelected
+    }
+  })
+}
+
 
 export default {
   findById,
-  findByIdAndWorryId
+  findByIdAndWorryId,
+  updateIsSelectedById
 };

--- a/src/repository/aloneOptionRepository.ts
+++ b/src/repository/aloneOptionRepository.ts
@@ -6,6 +6,17 @@ const findById = async (id: number) => {
   });
 }
 
+const findByIdAndWorryId = async (id: number, worryId: number) => {
+  return await prisma.aloneOption.findFirst({
+    where: {
+      id,
+      worryAloneId: worryId
+    }
+  });
+}
+
+
 export default {
-  findById
+  findById,
+  findByIdAndWorryId
 };

--- a/src/repository/worryAloneRepository.ts
+++ b/src/repository/worryAloneRepository.ts
@@ -53,4 +53,24 @@ const findFinalOption = async () => {
   });
 };
 
-export default { createAloneWorry, findAloneWorries, findFinalOption };
+const findById = async (id: number) => {
+  return await prisma.worryAlone.findUnique({
+    where: {
+      id
+    }
+  });
+}
+
+const updateFinalOption = async (aloneWorryId: number, chosenOptionId: number) => {
+  await prisma.worryAlone.update({
+    where: {
+      id: aloneWorryId
+    },
+    data: {
+      finalOption: chosenOptionId
+    }
+  })
+}
+
+
+export default { createAloneWorry, updateFinalOption, findById, findFinalOption, findAloneWorries };

--- a/src/repository/worryWithRepository.ts
+++ b/src/repository/worryWithRepository.ts
@@ -84,7 +84,7 @@ const findWorries = async () => {
 };
 
 const findById = async (id: number): Promise<worryWith | null> => {
-  return prisma.worryWith.findUnique({
+  return await prisma.worryWith.findUnique({
     where: {
       id,
     },

--- a/src/router/worryAloneRouter.ts
+++ b/src/router/worryAloneRouter.ts
@@ -26,4 +26,13 @@ router.post(
   worryAloneController.createAloneWorry
 );
 
+router.patch("/",
+  auth,
+  [
+    body("userId").notEmpty(),
+    body("worryAloneId").notEmpty(),
+    body("chosenOptionId").notEmpty()
+  ],
+  worryAloneController.patchWorryAlone);
+
 export default router;

--- a/src/service/worryAloneService.ts
+++ b/src/service/worryAloneService.ts
@@ -1,8 +1,10 @@
 import { CreateAloneWorryDTO } from "../interfaces/worryAlone/CreateAloneWorryDTO";
 import { worryAloneRepository } from "../repository";
+import aloneOptionRepository from '../repository/aloneOptionRepository';
 import { ClientException } from "../common/error/exceptions/customExceptions";
 import statusCode from "../constants/statusCode";
 import { WorryAlonePreview } from "../interfaces/worryAlone/WorryAlonePreview";
+import ChooseAloneWorryDTO from '../interfaces/worryAlone/ChooseAloneWorryDTO';
 
 const createAloneWorry = async (createAloneWorryDTO: CreateAloneWorryDTO) => {
   const aloneWorry = await worryAloneRepository.createAloneWorry(
@@ -32,6 +34,22 @@ const compareNotFinishedWorryFirst = (
   return -1;
 };
 
+const chooseFinalOption = async (chooseAloneWorryDTO: ChooseAloneWorryDTO) => {
+  const { aloneWorryId, userId, chosenOptionId } = chooseAloneWorryDTO;
+  const aloneWorry = await worryAloneRepository.findById(aloneWorryId);
+  if (!aloneWorry) {
+    throw new ClientException("해당하는 아이디의 고민글이 존재하지 않습니다");
+  }
+  if (aloneWorry.userId != userId) {
+    throw new ClientException("작성자가 아닙니다", statusCode.FORBIDDEN);
+  }
+  const chosenOption = await aloneOptionRepository.findById(chosenOptionId);
+  if (!chosenOption) {
+    throw new ClientException("해당하는 아이디의 선택지가 존재하지 않습니다");
+  }
+  await worryAloneRepository.updateFinalOption(aloneWorryId, chosenOptionId);
+}
+
 const compareFinishedWorryFirst = (
   a: WorryAlonePreview,
   b: WorryAlonePreview
@@ -60,9 +78,8 @@ const readAloneWorry = async (choiceEndedFirst: boolean) => {
   return sortedWorries;
 };
 
-const worryAloneService = {
+export default {
   createAloneWorry,
+  chooseFinalOption,
   readAloneWorry,
 };
-
-export default worryAloneService;

--- a/src/service/worryAloneService.ts
+++ b/src/service/worryAloneService.ts
@@ -34,6 +34,11 @@ const compareNotFinishedWorryFirst = (
   return -1;
 };
 
+const updateFinalOption = async (aloneWorryId: number, chosenOptionId: number) => {
+  await worryAloneRepository.updateFinalOption(aloneWorryId, chosenOptionId);
+  await aloneOptionRepository.updateIsSelectedById(chosenOptionId, true);
+}
+
 const chooseFinalOption = async (chooseAloneWorryDTO: ChooseAloneWorryDTO) => {
   const { aloneWorryId, userId, chosenOptionId } = chooseAloneWorryDTO;
   const aloneWorry = await worryAloneRepository.findById(aloneWorryId);
@@ -43,11 +48,14 @@ const chooseFinalOption = async (chooseAloneWorryDTO: ChooseAloneWorryDTO) => {
   if (aloneWorry.userId != userId) {
     throw new ClientException("작성자가 아닙니다", statusCode.FORBIDDEN);
   }
+  if (aloneWorry.finalOption) {
+    throw new ClientException("이미 최종 결정된 고민글입니다.");
+  }
   const chosenOption = await aloneOptionRepository.findByIdAndWorryId(chosenOptionId, aloneWorryId);
   if (!chosenOption) {
     throw new ClientException("해당 고민글의 선택지 아이디가 아닙니다.");
   }
-  await worryAloneRepository.updateFinalOption(aloneWorryId, chosenOptionId);
+  await updateFinalOption(aloneWorryId, chosenOptionId);
 }
 
 const compareFinishedWorryFirst = (

--- a/src/service/worryAloneService.ts
+++ b/src/service/worryAloneService.ts
@@ -43,9 +43,9 @@ const chooseFinalOption = async (chooseAloneWorryDTO: ChooseAloneWorryDTO) => {
   if (aloneWorry.userId != userId) {
     throw new ClientException("작성자가 아닙니다", statusCode.FORBIDDEN);
   }
-  const chosenOption = await aloneOptionRepository.findById(chosenOptionId);
+  const chosenOption = await aloneOptionRepository.findByIdAndWorryId(chosenOptionId, aloneWorryId);
   if (!chosenOption) {
-    throw new ClientException("해당하는 아이디의 선택지가 존재하지 않습니다");
+    throw new ClientException("해당 고민글의 선택지 아이디가 아닙니다.");
   }
   await worryAloneRepository.updateFinalOption(aloneWorryId, chosenOptionId);
 }

--- a/src/service/worryWithService.ts
+++ b/src/service/worryWithService.ts
@@ -26,6 +26,10 @@ const chooseFinalOption = async (
     );
   }
 
+  if (worryWith.finalOption) {
+    throw new ClientException("이미 최종 결정된 고민글입니다.");
+  }
+
   const chosenOption = await withOptionRepository.findById(optionId);
 
   if (!chosenOption) {

--- a/test/controller/worryAloneContoller.spec.ts
+++ b/test/controller/worryAloneContoller.spec.ts
@@ -1,0 +1,144 @@
+import { PrismaClient } from '@prisma/client';
+import request, { Response } from 'supertest';
+import app from '../testApp';
+import { worryAlone, aloneOption } from '@prisma/client'
+
+const prisma = new PrismaClient();
+
+describe("[PATCH] /worry/alone - 혼자 고민 결정하기", () => {
+  describe("올바른 요청일 경우", () => {
+    let response: Response;
+    beforeAll(async () => {
+      response = await request(app)
+        .patch('/api/worry/alone')
+        .send({ worryAloneId: 40, chosenOptionId: 88 });
+    });
+    afterAll(async () => {
+      await prisma.worryAlone.update({
+        where: {
+          id: 40
+        },
+        data: {
+          finalOption: null
+        }
+      });
+
+      await prisma.aloneOption.updateMany({
+        where: {
+          worryAloneId: 40
+        },
+        data: {
+          isSelected: false
+        }
+      });
+    });
+
+    it("200 응답을 반환한다.", () => {
+      expect(response.status).toBe(200);
+    });
+  });
+
+  describe("이미 결정한 고민일 경우", () => {
+    let response: Response;
+    let worryAlone: worryAlone;
+    let aloneOption: aloneOption
+    let originalWorryId: number;
+    beforeAll(async () => {
+      worryAlone = await prisma.worryAlone.findFirstOrThrow();
+      aloneOption = await prisma.aloneOption.findFirstOrThrow();
+      originalWorryId = aloneOption.worryAloneId;
+      await prisma.worryAlone.update({
+        where: {
+          id: worryAlone.id
+        },
+        data: {
+          finalOption: aloneOption.id
+        }
+      });
+      response = await request(app)
+        .patch('/api/worry/alone')
+        .send({ worryAloneId: worryAlone.id, chosenOptionId: 1 });
+    });
+
+    afterAll(async () => {
+      await prisma.worryAlone.update({
+        where: {
+          id: worryAlone.id
+        },
+        data: {
+          finalOption: null
+        }
+      });
+
+      await prisma.aloneOption.update({
+        where: {
+          id: aloneOption.id
+        },
+        data: {
+          worryAloneId: originalWorryId
+        }
+      });
+    })
+
+    it("400 에러를 반환한다.", () => {
+      expect(response.status).toBe(400);
+    })
+
+    it("올바른 메시지를 전달한다.", () => {
+      expect(response.body.message).toBe("이미 최종 결정된 고민글입니다.");
+    })
+  })
+  describe("고민글이 존재하지 않으면", () => {
+    let response: Response;
+
+    beforeAll(async () => {
+      response = await request(app)
+        .patch('/api/worry/alone')
+        .send({ worryAloneId: -1, chosenOptionId: 1 });
+    });
+    
+    it("400 에러를 반환한다.", () => {
+      expect(response.status).toBe(400);
+    });
+
+    it("올바른 메시지를 전달한다.", () => {
+      expect(response.body.message).toBe('해당하는 아이디의 고민글이 존재하지 않습니다');
+    });
+  })
+
+  describe("작성자가 아닌 경우", () => {
+    let response: Response;
+
+    beforeAll(async () => {
+      response = await request(app)
+        .patch('/api/worry/alone')
+        .send({ worryAloneId: 39, chosenOptionId: 86 });
+    });
+
+    it("403 에러를 반환한다.", () => {
+      expect(response.status).toBe(403);
+    });
+
+    it("올바른 메시지를 전달한다.", () => {
+      expect(response.body.message).toBe("작성자가 아닙니다");
+    });
+  });
+
+  describe("선택지 아이디가 올바르지 않은 경우", () => {
+    let response: Response;
+
+    beforeAll(async () => {
+      response = await request(app)
+        .patch('/api/worry/alone')
+        .send({ worryAloneId: 40, chosenOptionId: -1 });
+    });
+    
+    it("400 에러를 반환한다.", () => {
+      expect(response.status).toBe(400);
+    });
+
+    it("올바른 메시지를 전달한다.", () => {
+      expect(response.body.message).toBe('해당 고민글의 선택지 아이디가 아닙니다.');
+    });
+  });
+})

--- a/test/controller/worryWithController.spec.ts
+++ b/test/controller/worryWithController.spec.ts
@@ -1,11 +1,57 @@
+import { PrismaClient } from '@prisma/client';
 import request from 'supertest';
 import app from '../testApp';
+import { worryWith, withOption } from '@prisma/client';
+
+const prisma = new PrismaClient();
 
 describe("PATCH /worry/with", () => {
+  let createdWithWorry: worryWith;
+  let createdOption: withOption;
+
+  beforeAll(async () => {
+    createdWithWorry = await prisma.worryWith.create({
+      data: {
+        title: '제목',
+        content: '내용',
+        categoryId: 1,
+        userId: 3
+      }
+    });
+
+    createdOption = await prisma.withOption.create({
+      data: {
+        worryWithId: createdWithWorry.id,
+        title: '선택지다 이놈앙'
+      }
+    })
+  });
+
+  afterAll(async () => {
+    await prisma.worryWith.update({
+      where: {
+        id: createdWithWorry.id
+      },
+      data: {
+        finalOption: null
+      }
+    });
+    await prisma.withOption.delete({
+      where: {
+        id: createdOption.id
+      }
+    });
+    await prisma.worryWith.delete({
+      where: {
+        id: createdWithWorry.id
+      }
+    });
+  });
+
   it("올바른 응답", async () => {
     const response = await request(app)
       .patch("/api/worry/with")
-      .send({ worryWithId: 2, chosenOptionId: 2 });
+      .send({ worryWithId: createdWithWorry.id, chosenOptionId: createdOption.id });
     expect(response.statusCode).toBe(200);
     expect(response.body).toMatchObject({ status: 200, success: true, message: "나의고민 최종결정 성공" });
   }); 


### PR DESCRIPTION
**우선순위**

<!--
D-0 (ASAP)
긴급한 수정사항으로 바로 리뷰해 주세요.
앱의 오류로 인해 장애가 발생하거나, 빌드가 되지 않는 등 긴급 이슈가 발생할 때 사용합니다.
D-N (Within N days)
N일 이내에 리뷰해 주세요
-->

D-1

**변경사항**

- 혼자 고민글 최종 결정하기 api를 추가했어요.
- 최종 결정은 반복할 수 없기 때문에 검증하는 로직을 추가해줬습니다. (함께 고민에도 추가해주었어요)
- e2e 테스트를 작성했어요
  -  에러 상황도 테스트해봤습니당

**유의사항**

<!--
- 영향범위
- 중점적으로 pr 리뷰해줬으면 하는 부분
-->

- 뭐이리 검증할게 많은가요? 저 또 뭔가 빼먹었을 수도 있을 거같아요

**참조**

<!--
변경사항에 대해서 파악할 수 있는 링크 (노션, 슬랙, 위키 등)
-->

<img width="1135" alt="image" src="https://user-images.githubusercontent.com/61582017/211167615-eac9fe50-a689-4418-a492-27270cb2b931.png">

