### PR TITLE
[FIX] createWorryVote 에서 returnData 수정

### DIFF
--- a/src/service/voteService.ts
+++ b/src/service/voteService.ts
@@ -4,6 +4,7 @@ import statusCode from "../constants/statusCode";
 import { voteRepository, withOptionRepository, worryWithRepository } from "../repository"
 import { CreateVoteDTO, findVoteDTO } from "../interfaces/vote/worryVoteDTO";
 import { getFormattedDate } from "../common/utils/dateFormat";
+import worryWithService from './worryWithService';
 
 const createWorryVote = async (createVoteDTO: CreateVoteDTO) => {
 
@@ -30,61 +31,12 @@ const createWorryVote = async (createVoteDTO: CreateVoteDTO) => {
     }
 
     await voteRepository.createWorryVote(createVoteDTO);
-    //~ 해당 게시글의 선택지 id(optionId)를 가져온다.
-    const findWithOptionByWorryWithId = await withOptionRepository.findOptionsWithWorryId(createVoteDTO.worryWithId);
+    
 
-    const destructurePlainDataInWorryWith = (worryWith: any) => {
-        return {
-            worryId: worryWith.id,
-            title: worryWith.title,
-            content: worryWith.content,
-            finalOptionId: worryWith.finalOption,
-            commentOn: worryWith.commentOn,
-            commentCount: worryWith.commentCount
-        };
-    };
+    const afterVoteResult = await worryWithService.findWorryListByCategoryId(worryWith.categoryId,createVoteDTO.userId);
 
-    //! isVoted 로직
-    var isVoted: boolean = true;
-    var percentage: number = 0;
-    var countAllVote: number = 0;
-    var loginUserVoteId: number | undefined = 0;
+    return afterVoteResult;
 
-    //!TODO : 유저가 선택지 하나만 투표할 수 있도록
-    for (var i = 0; i < findWithOptionByWorryWithId.length; i++) {
-        const findVoteListByOptionId =
-            await voteRepository.findVoteListByOptionId(findWithOptionByWorryWithId[i].id);
-        countAllVote += findVoteListByOptionId.length;
-    }
-
-    //! percentage 계산 & option 작업
-    const option: Array<object> = [];
-    for (var i = 0; i < findWithOptionByWorryWithId.length; i++) {
-        //~ 해당 게시글의 optionId당 vote 결과
-        const findVoteListByOptionId =
-            await voteRepository.findVoteListByOptionId(
-                findWithOptionByWorryWithId[i].id
-            );
-        percentage = findVoteListByOptionId.length / countAllVote;
-        option.push({
-            id: findWithOptionByWorryWithId[i].id,
-            worryWithId: findWithOptionByWorryWithId[i].worryWithId,
-            title: findWithOptionByWorryWithId[i].title,
-            image: findWithOptionByWorryWithId[i].image,
-            hasImage: findWithOptionByWorryWithId[i].hasImage,
-            percentage: Math.round(percentage * 100),
-        });
-    }
-
-    const worryWithData = {
-        ...destructurePlainDataInWorryWith(worryWith),
-        createdAt: getFormattedDate(worryWith.createdAt),
-        isAuthor: worryWith.userId == createVoteDTO.userId ? true : false,
-        option,
-        isVoted,
-        loginUserVoteId,
-    };
-    return worryWithData;
 };
 
 const findWorryVoteByUserId = async (findVoteDTO: findVoteDTO) => {

--- a/src/service/worryWithService.ts
+++ b/src/service/worryWithService.ts
@@ -85,21 +85,21 @@ const findWorryListByCategoryId = async (
           await voteRepository.findVoteListByOptionId(
             findWithOptionByWorryWithId[i].id
           );
-        //! isVoted - 현재 로그인한 유저의 vote 결과를 가져와서 하나 이상이면 true
-        isVoted =
-          findVoteListByOptionId.filter((v) => v.userId != userId).length > 0
-            ? true
-            : false;
+        // //! isVoted - 현재 로그인한 유저의 vote 결과를 가져와서 하나 이상이면 true
+        // isVoted =
+        //   findVoteListByOptionId.filter((v) => v.userId != userId).length > 0
+        //     ? true
+        //     : false;
 
-        //~ 로그인한 유저가 투표했다면 어떤 선택지를 투표했는지 
-        if (isVoted) {
-          const findVoteByWorryWithId = await voteRepository.findVoteByOptionId(
-            findWithOptionByWorryWithId[i].id, userId
-          );
-          if (findVoteByWorryWithId?.userId == userId && findVoteByWorryWithId?.optionId > 0) {
-            loginUserVoteId = (findVoteByWorryWithId?.optionId > 0) ? findVoteByWorryWithId?.optionId : 0;
-          }
-        }
+        // //~ 로그인한 유저가 투표했다면 어떤 선택지를 투표했는지 
+        // if (isVoted) {
+        //   const findVoteByWorryWithId = await voteRepository.findVoteByOptionId(
+        //     findWithOptionByWorryWithId[i].id, userId
+        //   );
+        //   if (findVoteByWorryWithId?.userId == userId && findVoteByWorryWithId?.optionId > 0) {
+        //     loginUserVoteId = (findVoteByWorryWithId?.optionId > 0) ? findVoteByWorryWithId?.optionId : 0;
+        //   }
+        // }
         //! 해당 게시글의 전체 투표 개수
         countAllVote += findVoteListByOptionId.length;
       }
@@ -126,14 +126,23 @@ const findWorryListByCategoryId = async (
         });
       }
 
+      for(var i=0;i<worryWith.withOption.length;++i){
+        const optionVoted = await voteRepository.findVoteByOptionId(worryWith.withOption[i].id, userId);
+        if(optionVoted){
+          isVoted = true;
+          loginUserVoteId = optionVoted.optionId;
+          break;
+        }
+      }
+      
       const data = {
         ...destructurePlainDataInWorryWith(worryWith),
         createdAt: getFormattedDate(worryWith.createdAt),
         isAuthor: worryWith.userId == userId ? true : false,
-        category: worryWith.category.name,
-        option,
         isVoted,
         loginUserVoteId,
+        category: worryWith.category.name,
+        option,
       };
       return data;
     })


### PR DESCRIPTION
**우선순위**

<!--
D-0 (ASAP)
긴급한 수정사항으로 바로 리뷰해 주세요.
앱의 오류로 인해 장애가 발생하거나, 빌드가 되지 않는 등 긴급 이슈가 발생할 때 사용합니다.
D-N (Within N days)
N일 이내에 리뷰해 주세요
-->

D-0

**변경사항**
createWorryVote 함수에서 투표 성공후, 투표후의 결과를 return data 로 전달해주는데
이때 다시 return 하는 data를 만드는 것이 아니라 worryWithService 의 findWorryListByCategoryId 함수를 사용하여
data를 반환받음.
--> 중복되는 로직을 해당 로직을 가진 함수를 호출하는 것으로 대체
**유의사항**

<!--
- 영향범위
- 중점적으로 pr 리뷰해줬으면 하는 부분
-->

**참조**

<!--
변경사항에 대해서 파악할 수 있는 링크 (노션, 슬랙, 위키 등)
-->
